### PR TITLE
feat: support MacOS (continued)

### DIFF
--- a/core_lib/Cargo.lock
+++ b/core_lib/Cargo.lock
@@ -269,9 +269,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"

--- a/core_lib/Cargo.toml
+++ b/core_lib/Cargo.toml
@@ -9,11 +9,13 @@ authors = ["martichou"]
 name = "core_bin"
 path = "src/bin.rs"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+bluer = { version = "0.17.0", features = ["full"], optional = true }
+
 [dependencies]
 anyhow = "1.0"
 arboard = "3.3"
 base64 = "0.22"
-bluer = { version = "0.17", features = ["full"], optional = true }
 btleplug = "0.11"
 bytes = "1.5"
 directories = "5.0"

--- a/core_lib/src/hdl/mod.rs
+++ b/core_lib/src/hdl/mod.rs
@@ -8,11 +8,13 @@ use self::info::{InternalFileInfo, TransferMetadata};
 use crate::securegcm::ukey2_client_init::CipherCommitment;
 use crate::utils::RemoteDeviceInfo;
 
+#[cfg(not(target_os = "macos"))]
 mod ble;
+#[cfg(not(target_os = "macos"))]
 pub use ble::*;
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "experimental", not(target_os = "macos")))]
 mod blea;
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "experimental", not(target_os = "macos")))]
 pub use blea::*;
 mod inbound;
 pub use inbound::*;

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -18,6 +18,7 @@ use tauri_plugin_autostart::MacosLauncher;
 use tokio::sync::{broadcast, mpsc, watch};
 
 use crate::logger::set_up_logging;
+#[cfg(not(target_os = "macos"))]
 use crate::notification::{send_request_notification, send_temporarily_notification};
 use crate::store::{
     get_download_path, get_port, get_realclose, get_visibility, init_default, set_visibility,

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -18,7 +18,6 @@ use tauri_plugin_autostart::MacosLauncher;
 use tokio::sync::{broadcast, mpsc, watch};
 
 use crate::logger::set_up_logging;
-#[cfg(not(target_os = "macos"))]
 use crate::notification::{send_request_notification, send_temporarily_notification};
 use crate::store::{
     get_download_path, get_port, get_realclose, get_visibility, init_default, set_visibility,

--- a/frontend/src-tauri/src/notification.rs
+++ b/frontend/src-tauri/src/notification.rs
@@ -3,6 +3,7 @@ use rqs_lib::channel::{ChannelAction, ChannelDirection, ChannelMessage};
 use rqs_lib::Visibility;
 use tauri::{AppHandle, Manager};
 #[cfg(not(target_os = "linux"))]
+#[cfg(not(target_os = "macos"))]
 use tauri_plugin_notification::NotificationExt;
 
 use crate::cmds;
@@ -55,6 +56,7 @@ pub fn send_request_notification(name: String, id: String, app_handle: &AppHandl
     }
 
     #[cfg(not(target_os = "linux"))]
+    #[cfg(not(target_os = "macos"))]
     let _ = app_handle
         .notification()
         .builder()
@@ -63,6 +65,7 @@ pub fn send_request_notification(name: String, id: String, app_handle: &AppHandl
         .show();
 }
 
+#[cfg(not(target_os = "macos"))]
 pub fn send_temporarily_notification(app_handle: &AppHandle) {
     match Notification::new()
         .summary("RQuickShare")


### PR DESCRIPTION
This PR is based on pr #44.

1st commit is from @JurianOnderwater latest commit in PR #44 .
2nd commit adds partial notification support on MacOS (notificationHandle method not available on MacOS)

Possible improvements: move to Tauri 2.0 (currently in Beta) to have a fully-working notifiication module on MacOS.
