### PR TITLE
Add DNF

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ sudo dpkg -i r-quick-share_${VERSION}.deb
 sudo rpm -i r-quick-share-${VERSION}.rpm
 ```
 
+#### DNF (preferred over RPM)
+```bash
+sudo dnf install r-quick-share-${VERSION}.rpm
+```
+
 #### AppImage (no root required)
 
 AppImage is a little different. There's no installation needed, you simply have to give it the executable permission (+x on a chmod) to run it.


### PR DESCRIPTION
DNF is a lot more convenient for installing the RPM, as it will automatically find and download dependencies, unlike `rpm` (I had to learn this the hard way).