### PR TITLE
Handle non-UTF-8 endpoint_name by changing Protobuf field from string to bytes

### DIFF
--- a/core_lib/src/hdl/outbound.rs
+++ b/core_lib/src/hdl/outbound.rs
@@ -226,7 +226,7 @@ impl OutboundRequest {
                 ),
                 connection_request: Some(location_nearby_connections::ConnectionRequestFrame {
                     endpoint_id: Some(String::from_utf8_lossy(&self.endpoint_id).to_string()),
-                    endpoint_name: Some(sys_metrics::host::get_hostname()?),
+                    endpoint_name: Some(sys_metrics::host::get_hostname()?.into()),
                     endpoint_info: Some(
                         RemoteDeviceInfo {
                             name: sys_metrics::host::get_hostname()?,

--- a/core_lib/src/proto_src/offline_wire_formats.proto
+++ b/core_lib/src/proto_src/offline_wire_formats.proto
@@ -76,7 +76,7 @@ message ConnectionRequestFrame {
   // LINT.ThenChange(//depot/google3/third_party/nearby/proto/connections_enums.proto)
 
   optional string endpoint_id = 1;
-  optional string endpoint_name = 2;
+  optional bytes endpoint_name = 2;
   optional bytes handshake_data = 3;
   // A random number generated for each outgoing connection that is presently
   // used to act as a tiebreaker when 2 devices connect to each other


### PR DESCRIPTION
Changing "endpoint_name" from string to bytes allows "endpoint_name" to carry non-UTF-8 encoded data. I haven't confirmed, but I suspect Windows is something like Windows-1252 encoding. Adding ".into())" wraps the string into a Vec<u8> so it gets correctly serialized as bytes to match the changed protobuf definition. This tentatively fixes the other half of #141 .

I haven't tested Linux -> Linux or Linux <-> MacOS compatibility under this new format, but I can confirm that I am now able to successfully send and receive files back and forth between Linux, Android, and Windows freely with the usual/expected behaviors.