### PR TITLE
Fix Wi-Fi payload being empty for passwords of 16 characters

### DIFF
--- a/core_lib/src/hdl/inbound.rs
+++ b/core_lib/src/hdl/inbound.rs
@@ -611,10 +611,7 @@ impl InboundRequest {
                                                 anyhow::bail!("WiFi payload buffer ({buffer:?}) doesn't ends with 0x10 0x?? as expected");
                                             }
 
-                                            let len = *buffer
-                                                .get(1)
-                                                .expect("Validated for minimum length of 4")
-                                                as usize;
+                                            let len = buffer[1] as usize;
 
                                             let payload_buffer = buffer
                                                 .get(2..2 + len)

--- a/core_lib/src/hdl/inbound.rs
+++ b/core_lib/src/hdl/inbound.rs
@@ -592,18 +592,11 @@ impl InboundRequest {
                                         )
                                         .await;
                                     }
-                                    // FIXME: ChannelMessage's structure needs to be redone as well
-                                    // It needs to have TextPayloadInfo instead of TextPayloadType
                                     TextPayloadInfo::Wifi((_, ssid, security_type)) => {
-                                        // ~~Payload seems to be within two DLE (0x10) characters
-                                        // At least for WpaPsk, not sure about Wep~~
-                                        //
-                                        // Nope, that's wrong, my Wi-Fi password just happened to have 16 characters
-                                        // which tripped up the previous logic.
-                                        //
-                                        // So, the password seems to start with 0x0A followed by a byte indicating
-                                        // the password or payload length. And, the payload ends with 0x10 0x??
-                                        // The last byte is sometimes 00 and other times 01
+                                        // The password seems to start with a 0x0A byte followed by
+                                        // a byte indicating the password length. The payload ends
+                                        // with two bytes 0x10 0x??, the last unknown byte here is
+                                        // sometimes 0x00 and other times 0x01.
                                         fn parse_password_payload(
                                             buffer: &mut Vec<u8>,
                                         ) -> anyhow::Result<String>

--- a/core_lib/src/hdl/inbound.rs
+++ b/core_lib/src/hdl/inbound.rs
@@ -602,11 +602,13 @@ impl InboundRequest {
                                         ) -> anyhow::Result<String>
                                         {
                                             if buffer.len() < 4 {
-                                                anyhow::bail!("Buffer too short ({buffer:?})");
+                                                anyhow::bail!(
+                                                    "WiFi payload buffer is too short ({buffer:?})"
+                                                );
                                             }
 
                                             if buffer[(buffer.len() - 1) - 1] != 0x10 {
-                                                anyhow::bail!("Buffer ({buffer:?}) doesn't ends with 0x10 0x?? as expected");
+                                                anyhow::bail!("WiFi payload buffer ({buffer:?}) doesn't ends with 0x10 0x?? as expected");
                                             }
 
                                             let len = *buffer
@@ -614,7 +616,11 @@ impl InboundRequest {
                                                 .expect("Validated for minimum length of 4")
                                                 as usize;
 
-                                            let payload_buffer = buffer.get(2..2 + len).with_context(||anyhow!( "Buffer too short ({buffer:?}) can't retrieve payload of length {len}"))?;
+                                            let payload_buffer = buffer
+                                                .get(2..2 + len)
+                                                .with_context(
+                                                    || anyhow!("WiFi payload buffer is too short ({buffer:?}). Can't retrieve payload of length {len}")
+                                                )?;
 
                                             Ok(String::from_utf8(payload_buffer.to_owned())?)
                                         }

--- a/core_lib/src/hdl/mod.rs
+++ b/core_lib/src/hdl/mod.rs
@@ -6,6 +6,7 @@ use ts_rs::TS;
 
 use self::info::{InternalFileInfo, TransferMetadata};
 use crate::securegcm::ukey2_client_init::CipherCommitment;
+use crate::sharing_nearby::wifi_credentials_metadata::SecurityType;
 use crate::utils::RemoteDeviceInfo;
 
 #[cfg(feature = "experimental")]
@@ -89,7 +90,7 @@ pub struct InnerState {
 pub enum TextPayloadInfo {
     Url(i64),
     Text(i64),
-    Wifi((i64, String)),
+    Wifi((i64, String, SecurityType)), // id, ssid, security type
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
@@ -104,7 +105,7 @@ impl TextPayloadInfo {
         match self {
             TextPayloadInfo::Url(value)
             | TextPayloadInfo::Text(value)
-            | TextPayloadInfo::Wifi((value, _)) => value.to_owned(),
+            | TextPayloadInfo::Wifi((value, _, _)) => value.to_owned(),
         }
     }
 }


### PR DESCRIPTION
The problem with existing logic is that, when there's a password of length 16, the `end_index` ends up being `1` and the `payload` buffer being `[0x0A]` which is just a single line feed character when converted to UTF8 string.

https://github.com/Martichou/rquickshare/blob/378d8ae969941bee4bf60ad34ac9cf8bb7005eb7/core_lib/src/hdl/inbound.rs#L566-L568