### PR TITLE
Add support for custom device names

### DIFF
--- a/app/main/src-tauri/src/cmds/change_device_name.rs
+++ b/app/main/src-tauri/src/cmds/change_device_name.rs
@@ -1,0 +1,12 @@
+use crate::AppState;
+
+#[tauri::command]
+pub fn change_device_name(message: Option<String>, state: tauri::State<'_, AppState>) {
+    info!("device_name: {message:?}");
+
+    state
+        .rqs
+        .lock()
+        .unwrap()
+        .set_device_name(message);
+}

--- a/app/main/src-tauri/src/cmds/mod.rs
+++ b/app/main/src-tauri/src/cmds/mod.rs
@@ -1,5 +1,7 @@
 mod change_download_path;
 pub use change_download_path::*;
+mod change_device_name;
+pub use change_device_name::*;
 mod change_visibility;
 pub use change_visibility::*;
 mod discovery;

--- a/app/main/src-tauri/src/main.rs
+++ b/app/main/src-tauri/src/main.rs
@@ -24,7 +24,7 @@ use tokio::sync::{broadcast, mpsc, watch};
 use crate::logger::set_up_logging;
 use crate::notification::{send_request_notification, send_temporarily_notification};
 use crate::store::{
-    get_download_path, get_port, get_realclose, get_visibility, init_default, set_visibility,
+    get_device_name, get_download_path, get_port, get_realclose, get_visibility, init_default, set_visibility,
 };
 
 mod cmds;
@@ -63,6 +63,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .plugin(tauri_plugin_shell::init())
         .invoke_handler(tauri::generate_handler![
             cmds::change_download_path,
+            cmds::change_device_name,
             cmds::change_visibility,
             cmds::start_discovery,
             cmds::stop_discovery,
@@ -118,6 +119,7 @@ async fn main() -> Result<(), anyhow::Error> {
             let visibility = get_visibility(app.app_handle());
             let port_number = get_port(app.app_handle());
             let download_path = get_download_path(app.app_handle());
+            let device_name = get_device_name(app.app_handle());
 
             let app_handle = app.app_handle().clone();
             // This is not optimal, but until I find a better way to init log
@@ -127,7 +129,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 tauri::async_runtime::block_on(async move {
                     trace!("Beginning of RQS start");
                     // Start the RQuickShare service
-                    let mut rqs = RQS::new(visibility, port_number, download_path);
+                    let mut rqs = RQS::new(visibility, port_number, download_path, device_name);
                     let (sender_file, ble_receiver) = rqs.run().await.unwrap();
 
                     // Define state for tauri app

--- a/app/main/src-tauri/src/store.rs
+++ b/app/main/src-tauri/src/store.rs
@@ -75,6 +75,14 @@ pub fn get_download_path(app_handle: &AppHandle) -> Option<PathBuf> {
         .and_then(|json| json.as_str().map(PathBuf::from))
 }
 
+pub fn get_device_name(app_handle: &AppHandle) -> Option<String> {
+    let store = _get_store(app_handle);
+
+    store
+        .get("devicename")
+        .and_then(|json| json.as_str().map(String::from))
+}
+
 pub fn get_logging_level(app_handle: &AppHandle) -> Option<String> {
     let store = _get_store(app_handle);
 

--- a/app/main/src/components/HomePage.vue
+++ b/app/main/src/components/HomePage.vue
@@ -224,6 +224,7 @@ export default {
 			downloadPath: ref<string | undefined>(),
 
 			hostname: ref<string>(),
+			deviceName: ref<string>(),
 
 			settingsOpen: ref<boolean>(false),
 
@@ -234,6 +235,8 @@ export default {
 	mounted: function () {
 		nextTick(async () => {
 			this.hostname = await invoke('get_hostname');
+			await this.getDeviceName(this);
+
 			this.version = await getVersion();
 
 			await this.getVisibility(this);

--- a/app/main/src/composables/Heading.vue
+++ b/app/main/src/composables/Heading.vue
@@ -24,7 +24,7 @@ const emit = defineEmits(['openSettings']);
 				Device name
 			</h4>
 			<h2 class="text-2xl font-medium">
-				{{ vm.hostname }}
+				{{ vm.deviceName ?? vm.hostname }}
 			</h2>
 		</div>
 		<div class="flex justify-center items-center gap-4">

--- a/app/main/src/composables/SettingsModal.vue
+++ b/app/main/src/composables/SettingsModal.vue
@@ -65,6 +65,12 @@ function openDownloadPicker() {
 						</span>
 					</label>
 				</div>
+				<div class="form-control hover:bg-gray-500 hover:bg-opacity-10 rounded-xl p-3">
+					<label class="cursor-pointer flex flex-col items-start">
+						<span class="">Change device name</span>
+						<input :value="vm.deviceName" @input="event => utils.setDeviceName(vm, event.target.value)">
+					</label>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/app/main/src/vue_lib/helper/ParamsHelper.d.ts
+++ b/app/main/src/vue_lib/helper/ParamsHelper.d.ts
@@ -25,6 +25,7 @@ export interface TauriVM {
     visibility: Visibility;
     downloadPath: string | undefined;
     hostname: string | undefined;
+    deviceName: string | undefined;
     settingsOpen: boolean;
     new_version: string | null;
     enable: () => Promise<void>;

--- a/app/main/src/vue_lib/types.ts
+++ b/app/main/src/vue_lib/types.ts
@@ -37,6 +37,7 @@ export const numberToVisibility: { [key: number]: Visibility } = {
 };
 
 export const autostartKey = "autostart";
+export const deviceNameKey = "devicename";
 export const realcloseKey = "realclose";
 export const startminimizedKey = "startminimized";
 export const visibilityKey = "visibility";

--- a/app/main/src/vue_lib/utils.ts
+++ b/app/main/src/vue_lib/utils.ts
@@ -1,6 +1,6 @@
 import { Visibility } from '@martichou/core_lib/bindings/Visibility';
 import { TauriVM } from './helper/ParamsHelper';
-import { autostartKey, DisplayedItem, downloadPathKey, numberToVisibility, realcloseKey, startminimizedKey, stateToDisplay, visibilityKey, visibilityToNumber } from './types';
+import { autostartKey, DisplayedItem, deviceNameKey, downloadPathKey, numberToVisibility, realcloseKey, startminimizedKey, stateToDisplay, visibilityKey, visibilityToNumber } from './types';
 import { SendInfo } from '@martichou/core_lib/bindings/SendInfo';
 import { ChannelMessage } from '@martichou/core_lib/bindings/ChannelMessage';
 import { ChannelAction } from '@martichou/core_lib';
@@ -180,6 +180,29 @@ async function getDownloadPath(vm: TauriVM) {
 	vm.downloadPath = await vm.store.get(downloadPathKey) ?? undefined;
 }
 
+function normalizeDeviceName(name: string) {
+	if (name === undefined || name === null) {
+		return undefined;
+	}
+	name = name.trim();
+	if (name === '') {
+		return undefined;
+	}
+	return name;
+}
+
+async function setDeviceName(vm: TauriVM, name: string) {
+	name = normalizeDeviceName(name);
+	await vm.invoke('change_device_name', { message: name });
+	await name === undefined ? vm.store.delete(deviceNameKey) : vm.store.set(deviceNameKey, name);
+	await vm.store.save();
+	vm.deviceName = name;
+}
+
+async function getDeviceName(vm: TauriVM) {
+	vm.deviceName = await vm.store.get(deviceNameKey) ?? undefined;
+}
+
 async function getLatestVersion(vm: TauriVM) {
 	try {
 		const response = await fetch('https://api.github.com/repos/martichou/rquickshare/releases/latest');
@@ -216,6 +239,8 @@ export const utils = {
 	getProgress,
 	setDownloadPath,
 	getDownloadPath,
+	setDeviceName,
+	getDeviceName,
 	getLatestVersion,
 	setStartMinimized,
 	getStartMinimized


### PR DESCRIPTION
Adds an option in the settings menu for the user to specify a custom device name.
Empty or entirely whitespace values will be treated as unset.

On the ts/vue side, names are stored as string/undefined with normalization of empty/whitespace strings to undefined.
On the rust side, names are stored as Option<String>.

If a valid custom device name is specified, it will be used in place of the hostname in mdns advertisements.
If no device name or an invalid device name is specified, the hostname will be used as a fallback.

Fixes #310 