### PR TITLE
feat: Add trusted devices with auto-accept functionality

### DIFF
--- a/app/main/src-tauri/src/main.rs
+++ b/app/main/src-tauri/src/main.rs
@@ -24,7 +24,8 @@ use tokio::sync::{broadcast, mpsc, watch};
 use crate::logger::set_up_logging;
 use crate::notification::{send_request_notification, send_temporarily_notification};
 use crate::store::{
-    get_download_path, get_port, get_realclose, get_visibility, init_default, set_visibility,
+    get_download_path, get_port, get_realclose, get_visibility, init_default,
+    is_device_trusted_and_valid, set_visibility,
 };
 
 mod cmds;
@@ -200,7 +201,11 @@ fn spawn_receiver_tasks(app_handle: &AppHandle) {
                             .and_then(|meta| meta.source.as_ref())
                             .map(|source| source.name.clone())
                             .unwrap_or_else(|| "Unknown".to_string());
-                        send_request_notification(name, info.id.clone(), &capp_handle);
+
+                        // Only show notification if device is not trusted (will be auto-accepted)
+                        if !is_device_trusted_and_valid(&capp_handle, &name) {
+                            send_request_notification(name, info.id.clone(), &capp_handle);
+                        }
                     }
                     rs2js_channelmessage(info, &capp_handle);
                 }

--- a/app/main/src-tauri/src/store.rs
+++ b/app/main/src-tauri/src/store.rs
@@ -91,3 +91,45 @@ pub fn get_startminimized(app_handle: &AppHandle) -> bool {
         .and_then(|json| json.as_bool())
         .unwrap_or_default()
 }
+
+pub fn is_device_trusted_and_valid(app_handle: &AppHandle, device_name: &str) -> bool {
+    let store = _get_store(app_handle);
+
+    // Get timeout in minutes (default 5 minutes)
+    let timeout_minutes = store
+        .get("auto_accept_timeout")
+        .and_then(|json| json.as_u64())
+        .unwrap_or(5);
+
+    let timeout_ms = timeout_minutes * 60 * 1000;
+
+    // Get trusted devices array
+    let trusted_devices = match store.get("trusted_devices") {
+        Some(json) => json,
+        None => return false,
+    };
+
+    let devices = match trusted_devices.as_array() {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    // Find device by name and check if within timeout
+    for device in devices {
+        let name = device.get("name").and_then(|v| v.as_str());
+        let last_transfer = device.get("lastTransfer").and_then(|v| v.as_u64());
+
+        if let (Some(name), Some(last_transfer)) = (name, last_transfer) {
+            if name == device_name {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
+
+                return (now - last_transfer) < timeout_ms;
+            }
+        }
+    }
+
+    false
+}

--- a/app/main/src/components/HomePage.vue
+++ b/app/main/src/components/HomePage.vue
@@ -14,7 +14,6 @@
 				<TrustDeviceCallout
 					:vm="vm"
 					@trust="handleTrustAccept"
-					@decline="handleTrustDecline"
 					@block="handleTrustBlock" />
 
 				<div
@@ -434,9 +433,6 @@ export default {
 			const requestId = this.pendingTrustRequest.id;
 			this.clearPendingTrustRequest(this);
 			await this.sendCmd(this, requestId, 'AcceptTransfer');
-		},
-		handleTrustDecline: async function() {
-			this.clearPendingTrustRequest(this);
 		},
 		handleTrustBlock: async function() {
 			this.clearPendingTrustRequest(this);

--- a/app/main/src/components/HomePage.vue
+++ b/app/main/src/components/HomePage.vue
@@ -11,6 +11,12 @@
 			<div class="flex-1 flex flex-col bg-white w-full max-w-full min-w-0 min-h-full rounded-tl-[3rem] p-12 h-1 overflow-y-scroll">
 				<ContentStatus :vm="vm" @outbound-payload="(el: OutboundPayload) => outboundPayload = el" @discovery-running="discoveryRunning = true;" />
 
+				<TrustDeviceCallout
+					:vm="vm"
+					@trust="handleTrustAccept"
+					@decline="handleTrustDecline"
+					@block="handleTrustBlock" />
+
 				<div
 					v-for="item in displayedItems" :key="item.id" class="w-full rounded-3xl flex flex-row gap-6 p-4 mb-4 bg-green-100"
 					:class="{'cursor-pointer': item.endpoint}" @click="item.endpoint && sendInfo(vm, item.id)">
@@ -27,7 +33,7 @@
 							<p class="mt-4">
 								Wants to share {{ item.files?.join(', ') ?? item.text_description ?? 'some file(s).' }}
 							</p>
-							<div class="flex flex-row justify-end gap-4 mt-1">
+							<div class="flex flex-row justify-end gap-2 mt-1 flex-wrap">
 								<p
 									@click.stop="sendCmd(vm, item.id, 'AcceptTransfer')" class="btn px-3
 									rounded-xl active:scale-95 transition duration-150 ease-in-out shadow-none">
@@ -161,13 +167,14 @@ import { EndpointInfo } from '@martichou/core_lib/bindings/EndpointInfo';
 import { OutboundPayload } from '@martichou/core_lib/bindings/OutboundPayload';
 import { Visibility } from '@martichou/core_lib/bindings/Visibility';
 
-import { ToastNotification, ToDelete, stateToDisplay, autostartKey, DisplayedItem, useToastStore, opt, ToastType, utils } from '../vue_lib';
+import { ToastNotification, ToDelete, stateToDisplay, autostartKey, DisplayedItem, useToastStore, opt, ToastType, utils, AutoAcceptTimeout, TrustedDevice, BlockedDevice, PendingTrustRequest } from '../vue_lib';
 
 import SettingsModal from '../composables/SettingsModal.vue';
 import Heading from '../composables/Heading.vue';
 import SideMenu from '../composables/SideMenu.vue';
 import ContentStatus from '../composables/ContentStatus.vue';
 import ItemSide from '../composables/ItemSide.vue';
+import TrustDeviceCallout from '../composables/TrustDeviceCallout.vue';
 
 export default {
 	name: "HomePage",
@@ -178,7 +185,8 @@ export default {
 		Heading,
 		SideMenu,
 		ContentStatus,
-		ItemSide
+		ItemSide,
+		TrustDeviceCallout
 	},
 
 	async setup() {
@@ -228,6 +236,11 @@ export default {
 			settingsOpen: ref<boolean>(false),
 
 			new_version: opt<string>(),
+
+			autoAcceptTimeout: ref<AutoAcceptTimeout>(5),
+			trustedDevices: ref<TrustedDevice[]>([]),
+			blockedDevices: ref<BlockedDevice[]>([]),
+			pendingTrustRequest: ref<PendingTrustRequest | null>(null),
 		};
 	},
 
@@ -247,6 +260,9 @@ export default {
 			await this.getRealclose(this);
 			await this.getStartMinimized(this);
 			await this.getDownloadPath(this);
+			await this.getAutoAcceptTimeout(this);
+			await this.getTrustedDevices(this);
+			await this.getBlockedDevices(this);
 
 			// Check permission for notification
 			let permissionGranted = await isPermissionGranted();
@@ -267,7 +283,46 @@ export default {
 						});
 					}
 
-					// TODO - Automatically open || copy to clipboard + toast
+					// Handle incoming transfer request
+					if (cm.state === "WaitingForUserConsent") {
+						const deviceName = cm.meta?.source?.name;
+						const deviceType = cm.meta?.source?.device_type ?? 'Unknown';
+
+						if (deviceName) {
+							// Check if device is blocked - silently ignore
+							if (this.isDeviceBlocked(this, deviceName)) {
+								// Device is blocked, do nothing (user must manually accept/decline)
+							}
+							// Check if device is trusted and within timeout - auto-accept
+							else if (this.isTrustedAndValid(this, deviceName)) {
+								await this.updateTrustedDeviceTimestamp(this, deviceName);
+								await this.sendCmd(this, cm.id, 'AcceptTransfer');
+							}
+							// Show trust prompt for new/expired devices
+							else if (this.shouldShowTrustPrompt(this, deviceName)) {
+								this.setPendingTrustRequest(this, cm.id, deviceName, deviceType);
+							}
+						}
+					}
+
+					// Update trusted device timestamp on successful transfer
+					if (cm.state === "Finished") {
+						const deviceName = cm.meta?.source?.name;
+						if (deviceName && this.isTrustedAndValid(this, deviceName)) {
+							await this.updateTrustedDeviceTimestamp(this, deviceName);
+						}
+						// Clear pending trust request if it matches
+						if (this.pendingTrustRequest?.id === cm.id) {
+							this.clearPendingTrustRequest(this);
+						}
+					}
+
+					// Clear pending trust request on terminal states
+					if (['Rejected', 'Cancelled', 'Disconnected'].includes(cm.state ?? '')) {
+						if (this.pendingTrustRequest?.id === cm.id) {
+							this.clearPendingTrustRequest(this);
+						}
+					}
 
 					if (idx !== -1) {
 						const prev = this.requests.at(idx);
@@ -373,6 +428,18 @@ export default {
 				this.toastStore.addToast("Error opening URL, it may not be a valid URI", ToastType.Error);
 				console.error("Error opening URL", e);
 			}
+		},
+		handleTrustAccept: async function() {
+			if (!this.pendingTrustRequest) return;
+			const requestId = this.pendingTrustRequest.id;
+			this.clearPendingTrustRequest(this);
+			await this.sendCmd(this, requestId, 'AcceptTransfer');
+		},
+		handleTrustDecline: async function() {
+			this.clearPendingTrustRequest(this);
+		},
+		handleTrustBlock: async function() {
+			this.clearPendingTrustRequest(this);
 		},
 	},
 }

--- a/app/main/src/composables/SettingsModal.vue
+++ b/app/main/src/composables/SettingsModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { utils } from '../vue_lib';
-import { PropType } from 'vue';
+import { utils, autoAcceptTimeoutOptions, AutoAcceptTimeout, TrustedDevice } from '../vue_lib';
+import { PropType, computed, ref, watch, onUnmounted } from 'vue';
 import { TauriVM } from '../vue_lib/helper/ParamsHelper';
 
 const props = defineProps({
@@ -11,6 +11,62 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['close']);
+
+// Timer for countdown updates
+let countdownInterval: ReturnType<typeof setInterval> | null = null;
+const now = ref(Date.now());
+
+// Watch for settings modal opening/closing
+watch(() => props.vm.settingsOpen, async (isOpen) => {
+	if (isOpen) {
+		// Refresh trusted devices when opening settings (removes expired ones)
+		await utils.getTrustedDevices(props.vm);
+		// Start countdown timer
+		now.value = Date.now();
+		countdownInterval = setInterval(() => {
+			now.value = Date.now();
+			// Also check for expired devices and remove them
+			checkAndRemoveExpired();
+		}, 1000);
+	} else {
+		// Stop timer when closing
+		if (countdownInterval) {
+			clearInterval(countdownInterval);
+			countdownInterval = null;
+		}
+	}
+});
+
+onUnmounted(() => {
+	if (countdownInterval) {
+		clearInterval(countdownInterval);
+	}
+});
+
+async function checkAndRemoveExpired() {
+	const timeoutMs = props.vm.autoAcceptTimeout * 60 * 1000;
+	const expired = props.vm.trustedDevices.filter(d => (now.value - d.lastTransfer) >= timeoutMs);
+	for (const device of expired) {
+		await utils.removeTrustedDevice(props.vm, device.name);
+	}
+}
+
+function getTimeRemaining(device: TrustedDevice): string {
+	const timeoutMs = props.vm.autoAcceptTimeout * 60 * 1000;
+	const elapsed = now.value - device.lastTransfer;
+	const remaining = timeoutMs - elapsed;
+
+	if (remaining <= 0) return 'Expired';
+
+	const totalSeconds = Math.floor(remaining / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+
+	if (minutes > 0) {
+		return `${minutes}m ${seconds}s`;
+	}
+	return `${seconds}s`;
+}
 
 function openDownloadPicker() {
 	props.vm.dialogOpen({
@@ -25,6 +81,24 @@ function openDownloadPicker() {
 		await utils.setDownloadPath(props.vm, el as string);
 	});
 }
+
+function onAutoAcceptTimeoutChange(event: Event) {
+	const target = event.target as HTMLSelectElement;
+	const value = parseInt(target.value) as AutoAcceptTimeout;
+	utils.setAutoAcceptTimeout(props.vm, value);
+}
+
+async function removeTrusted(name: string) {
+	await utils.removeTrustedDevice(props.vm, name);
+}
+
+async function removeBlocked(name: string) {
+	await utils.removeBlockedDevice(props.vm, name);
+}
+
+const hasDevices = computed(() => {
+	return props.vm.trustedDevices.length > 0 || props.vm.blockedDevices.length > 0;
+});
 </script>
 
 <template>
@@ -64,6 +138,66 @@ function openDownloadPicker() {
 							> {{ vm.downloadPath ?? 'OS User\'s download folder' }}
 						</span>
 					</label>
+				</div>
+				<div class="form-control hover:bg-gray-500 hover:bg-opacity-10 rounded-xl p-3">
+					<label class="flex flex-row justify-between items-center">
+						<span class="label-text">Auto-accept timeout</span>
+						<select
+							class="select select-sm bg-gray-100 focus:outline-none"
+							:value="vm.autoAcceptTimeout"
+							@change="onAutoAcceptTimeoutChange">
+							<option
+								v-for="option in autoAcceptTimeoutOptions"
+								:key="option.value"
+								:value="option.value">
+								{{ option.label }}
+							</option>
+						</select>
+					</label>
+				</div>
+
+				<!-- Devices Section -->
+				<div v-if="hasDevices" class="mt-4 pt-4 border-t border-gray-200">
+					<h4 class="font-medium text-sm text-gray-700 mb-2">Devices</h4>
+
+					<!-- Trusted Devices -->
+					<div v-if="vm.trustedDevices.length > 0" class="mb-3">
+						<p class="text-xs text-gray-500 mb-1">Trusted (auto-accept enabled)</p>
+						<div
+							v-for="device in vm.trustedDevices"
+							:key="device.name"
+							class="flex flex-row justify-between items-center py-2 px-3 hover:bg-gray-50 rounded-lg"
+						>
+							<div class="flex flex-col min-w-0 flex-1">
+								<span class="text-sm truncate">{{ device.name }}</span>
+								<span class="text-xs text-gray-400">Expires in {{ getTimeRemaining(device) }}</span>
+							</div>
+							<button
+								@click="removeTrusted(device.name)"
+								class="text-xs text-red-500 hover:text-red-700 ml-2 flex-shrink-0"
+							>
+								Remove
+							</button>
+						</div>
+					</div>
+
+					<!-- Blocked Devices -->
+					<div v-if="vm.blockedDevices.length > 0">
+						<p class="text-xs text-gray-500 mb-1">Blocked (won't ask to trust)</p>
+						<div
+							v-for="device in vm.blockedDevices"
+							:key="device.name"
+							class="flex flex-row justify-between items-center py-2 px-3 hover:bg-gray-50 rounded-lg"
+						>
+							<span class="text-sm truncate flex-1">{{ device.name }}</span>
+							<button
+								@click="removeBlocked(device.name)"
+								class="text-xs text-blue-500 hover:text-blue-700 ml-2"
+							>
+								Unblock
+							</button>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/app/main/src/composables/TrustDeviceCallout.vue
+++ b/app/main/src/composables/TrustDeviceCallout.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { PropType } from 'vue';
+import { TauriVM } from '../vue_lib/helper/ParamsHelper';
+import { utils } from '../vue_lib';
+
+const props = defineProps({
+	vm: {
+		type: Object as PropType<TauriVM>,
+		required: true
+	}
+});
+
+const emit = defineEmits(['trust', 'decline', 'block']);
+
+async function handleTrust() {
+	if (!props.vm.pendingTrustRequest) return;
+	const { name, deviceType } = props.vm.pendingTrustRequest;
+	await utils.addTrustedDevice(props.vm, name, deviceType);
+	emit('trust');
+}
+
+async function handleBlock() {
+	if (!props.vm.pendingTrustRequest) return;
+	const { name, deviceType } = props.vm.pendingTrustRequest;
+	await utils.addBlockedDevice(props.vm, name, deviceType);
+	emit('block');
+}
+</script>
+
+<template>
+	<div
+		v-if="vm.pendingTrustRequest"
+		class="bg-blue-50 border border-blue-200 rounded-xl p-4 mb-4 shadow-sm"
+	>
+		<div class="flex flex-col gap-3">
+			<div class="flex items-start gap-3">
+				<div class="flex-shrink-0 w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
+					<svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+					</svg>
+				</div>
+				<div class="flex-1">
+					<h4 class="font-medium text-blue-900">
+						Trust "{{ vm.pendingTrustRequest.name }}"?
+					</h4>
+					<p class="text-sm text-blue-700 mt-1">
+						Auto-accept incoming transfers from this device when the last transfer was within {{ vm.autoAcceptTimeout }} {{ vm.autoAcceptTimeout === 1 ? 'minute' : 'minutes' }}.
+					</p>
+				</div>
+			</div>
+			<div class="flex flex-row justify-end gap-2 flex-wrap">
+				<button
+					@click="handleTrust"
+					class="btn px-3 py-1 rounded-xl bg-blue-600 text-white hover:bg-blue-700 active:scale-95 transition duration-150 ease-in-out shadow-none text-sm"
+				>
+					Yes, trust
+				</button>
+				<button
+					@click="handleBlock"
+					class="btn px-3 py-1 rounded-xl bg-gray-100 text-gray-600 hover:bg-gray-200 active:scale-95 transition duration-150 ease-in-out shadow-none text-sm"
+				>
+					Don't ask again
+				</button>
+			</div>
+		</div>
+	</div>
+</template>

--- a/app/main/src/composables/TrustDeviceCallout.vue
+++ b/app/main/src/composables/TrustDeviceCallout.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 	}
 });
 
-const emit = defineEmits(['trust', 'decline', 'block']);
+const emit = defineEmits(['trust', 'block']);
 
 async function handleTrust() {
 	if (!props.vm.pendingTrustRequest) return;

--- a/app/main/src/vue_lib/helper/ParamsHelper.d.ts
+++ b/app/main/src/vue_lib/helper/ParamsHelper.d.ts
@@ -1,7 +1,7 @@
 import { Store } from '@tauri-apps/plugin-store';
 import { UnlistenFn } from '@tauri-apps/api/event';
 
-import { ToDelete } from '../types';
+import { AutoAcceptTimeout, BlockedDevice, PendingTrustRequest, ToDelete, TrustedDevice } from '../types';
 
 import { EndpointInfo } from '@martichou/core_lib/bindings/EndpointInfo';
 import { Visibility } from '@martichou/core_lib/bindings/Visibility';
@@ -27,6 +27,10 @@ export interface TauriVM {
     hostname: string | undefined;
     settingsOpen: boolean;
     new_version: string | null;
+    autoAcceptTimeout: AutoAcceptTimeout;
+    trustedDevices: TrustedDevice[];
+    blockedDevices: BlockedDevice[];
+    pendingTrustRequest: PendingTrustRequest | null;
     enable: () => Promise<void>;
     disable: () => Promise<void>;
     invoke: (cmd: string, args?: InvokeArgs) => Promise<unknown>

--- a/app/main/src/vue_lib/types.ts
+++ b/app/main/src/vue_lib/types.ts
@@ -41,6 +41,36 @@ export const realcloseKey = "realclose";
 export const startminimizedKey = "startminimized";
 export const visibilityKey = "visibility";
 export const downloadPathKey = "download_path";
+export const autoAcceptTimeoutKey = "auto_accept_timeout";
+export const trustedDevicesKey = "trusted_devices";
+export const blockedDevicesKey = "blocked_devices";
+
+export type AutoAcceptTimeout = 1 | 5 | 10 | 60;
+
+export const autoAcceptTimeoutOptions: { value: AutoAcceptTimeout; label: string }[] = [
+	{ value: 1, label: '1 minute' },
+	{ value: 5, label: '5 minutes' },
+	{ value: 10, label: '10 minutes' },
+	{ value: 60, label: '1 hour' },
+];
+
+export interface TrustedDevice {
+	name: string;
+	deviceType: string;
+	lastTransfer: number;
+}
+
+export interface BlockedDevice {
+	name: string;
+	deviceType: string;
+	blockedAt: number;
+}
+
+export interface PendingTrustRequest {
+	id: string;
+	name: string;
+	deviceType: string;
+}
 export const stateToDisplay: Array<Partial<State>> = ["ReceivedPairedKeyResult", "WaitingForUserConsent", "ReceivingFiles", "Disconnected",
 	"Finished", "SentIntroduction", "SendingFiles", "Cancelled", "Rejected"]
 

--- a/app/main/src/vue_lib/utils.ts
+++ b/app/main/src/vue_lib/utils.ts
@@ -1,6 +1,6 @@
 import { Visibility } from '@martichou/core_lib/bindings/Visibility';
 import { TauriVM } from './helper/ParamsHelper';
-import { autostartKey, DisplayedItem, downloadPathKey, numberToVisibility, realcloseKey, startminimizedKey, stateToDisplay, visibilityKey, visibilityToNumber } from './types';
+import { autostartKey, AutoAcceptTimeout, autoAcceptTimeoutKey, blockedDevicesKey, BlockedDevice, DisplayedItem, downloadPathKey, numberToVisibility, realcloseKey, startminimizedKey, stateToDisplay, trustedDevicesKey, TrustedDevice, visibilityKey, visibilityToNumber } from './types';
 import { SendInfo } from '@martichou/core_lib/bindings/SendInfo';
 import { ChannelMessage } from '@martichou/core_lib/bindings/ChannelMessage';
 import { ChannelAction } from '@martichou/core_lib';
@@ -198,6 +198,124 @@ async function getLatestVersion(vm: TauriVM) {
 	}
 }
 
+async function setAutoAcceptTimeout(vm: TauriVM, timeout: AutoAcceptTimeout) {
+	await vm.store.set(autoAcceptTimeoutKey, timeout);
+	await vm.store.save();
+	vm.autoAcceptTimeout = timeout;
+}
+
+async function getAutoAcceptTimeout(vm: TauriVM) {
+	vm.autoAcceptTimeout = (await vm.store.get(autoAcceptTimeoutKey) as AutoAcceptTimeout | null) ?? 5;
+}
+
+// Trusted devices management
+async function getTrustedDevices(vm: TauriVM) {
+	const allDevices = (await vm.store.get(trustedDevicesKey) as TrustedDevice[] | null) ?? [];
+	const timeoutMs = vm.autoAcceptTimeout * 60 * 1000;
+	const now = Date.now();
+
+	// Filter out expired devices
+	const validDevices = allDevices.filter(d => (now - d.lastTransfer) < timeoutMs);
+
+	// If any were removed, save the cleaned list
+	if (validDevices.length !== allDevices.length) {
+		vm.trustedDevices = validDevices;
+		await saveTrustedDevices(vm);
+	} else {
+		vm.trustedDevices = validDevices;
+	}
+}
+
+async function saveTrustedDevices(vm: TauriVM) {
+	await vm.store.set(trustedDevicesKey, vm.trustedDevices);
+	await vm.store.save();
+}
+
+async function addTrustedDevice(vm: TauriVM, name: string, deviceType: string) {
+	const existing = vm.trustedDevices.findIndex(d => d.name === name);
+	const device: TrustedDevice = { name, deviceType, lastTransfer: Date.now() };
+
+	if (existing !== -1) {
+		vm.trustedDevices.splice(existing, 1, device);
+	} else {
+		vm.trustedDevices.push(device);
+	}
+	await saveTrustedDevices(vm);
+}
+
+async function removeTrustedDevice(vm: TauriVM, name: string) {
+	const idx = vm.trustedDevices.findIndex(d => d.name === name);
+	if (idx !== -1) {
+		vm.trustedDevices.splice(idx, 1);
+		await saveTrustedDevices(vm);
+	}
+}
+
+async function updateTrustedDeviceTimestamp(vm: TauriVM, name: string) {
+	const device = vm.trustedDevices.find(d => d.name === name);
+	if (device) {
+		device.lastTransfer = Date.now();
+		await saveTrustedDevices(vm);
+	}
+}
+
+function isTrustedAndValid(vm: TauriVM, name: string): boolean {
+	const device = vm.trustedDevices.find(d => d.name === name);
+	if (!device) return false;
+
+	const timeoutMs = vm.autoAcceptTimeout * 60 * 1000;
+	return (Date.now() - device.lastTransfer) < timeoutMs;
+}
+
+function shouldShowTrustPrompt(vm: TauriVM, name: string): boolean {
+	// Don't show if device is blocked
+	if (vm.blockedDevices.some(d => d.name === name)) return false;
+
+	// Don't show if device is trusted and within timeout
+	if (isTrustedAndValid(vm, name)) return false;
+
+	return true;
+}
+
+// Blocked devices management
+async function getBlockedDevices(vm: TauriVM) {
+	vm.blockedDevices = (await vm.store.get(blockedDevicesKey) as BlockedDevice[] | null) ?? [];
+}
+
+async function saveBlockedDevices(vm: TauriVM) {
+	await vm.store.set(blockedDevicesKey, vm.blockedDevices);
+	await vm.store.save();
+}
+
+async function addBlockedDevice(vm: TauriVM, name: string, deviceType: string) {
+	const existing = vm.blockedDevices.findIndex(d => d.name === name);
+	if (existing === -1) {
+		vm.blockedDevices.push({ name, deviceType, blockedAt: Date.now() });
+		await saveBlockedDevices(vm);
+	}
+}
+
+async function removeBlockedDevice(vm: TauriVM, name: string) {
+	const idx = vm.blockedDevices.findIndex(d => d.name === name);
+	if (idx !== -1) {
+		vm.blockedDevices.splice(idx, 1);
+		await saveBlockedDevices(vm);
+	}
+}
+
+function isDeviceBlocked(vm: TauriVM, name: string): boolean {
+	return vm.blockedDevices.some(d => d.name === name);
+}
+
+// Pending trust request management
+function setPendingTrustRequest(vm: TauriVM, id: string, name: string, deviceType: string) {
+	vm.pendingTrustRequest = { id, name, deviceType };
+}
+
+function clearPendingTrustRequest(vm: TauriVM) {
+	vm.pendingTrustRequest = null;
+}
+
 // Default export
 export const utils = {
 	_displayedItems,
@@ -218,6 +336,23 @@ export const utils = {
 	getDownloadPath,
 	getLatestVersion,
 	setStartMinimized,
-	getStartMinimized
+	getStartMinimized,
+	setAutoAcceptTimeout,
+	getAutoAcceptTimeout,
+	// Trusted devices
+	getTrustedDevices,
+	addTrustedDevice,
+	removeTrustedDevice,
+	updateTrustedDeviceTimestamp,
+	isTrustedAndValid,
+	shouldShowTrustPrompt,
+	// Blocked devices
+	getBlockedDevices,
+	addBlockedDevice,
+	removeBlockedDevice,
+	isDeviceBlocked,
+	// Pending trust request
+	setPendingTrustRequest,
+	clearPendingTrustRequest,
 };
 export type UtilsType = typeof utils;


### PR DESCRIPTION
## Summary
- Added ability to trust devices for automatic file acceptance within a configurable timeout
- New callout banner appears when receiving files from new/expired devices with options:
  - "Yes, trust" - adds device to trusted list
  - "Don't ask again" - blocks device from future prompts
- Added Settings > Devices section to manage trusted and blocked devices
- Trusted devices show countdown timer "Expires in Xm Ys"
- System notifications are suppressed for auto-accepted transfers from trusted devices
- Expired trusted devices are automatically cleaned up

<img width="910" height="657" alt="image" src="https://github.com/user-attachments/assets/3b7b4d07-fef3-4f5c-b8cf-186ae9caca58" />

Trusted devices
<img width="910" height="657" alt="image" src="https://github.com/user-attachments/assets/694d7d6d-96cf-4014-9c56-dafbb6077b3f" />

No trusted devices
<img width="910" height="657" alt="image" src="https://github.com/user-attachments/assets/beb2a0b5-4a82-408d-8769-f096d9de2be0" />




## Features
- Configurable auto-accept timeout (1, 5, 10, 60 minutes)
- Persistent storage for trusted and blocked devices
- Real-time countdown updates in settings
- Automatic cleanup of expired devices

## Test plan
- [ ] Send file from new device, verify trust callout appears
- [ ] Click "Yes, trust" and send another file within timeout, verify auto-accept
- [ ] Check Settings > Devices shows trusted device with countdown
- [ ] Wait for timeout and verify device is removed
- [ ] Test "Don't ask again" blocks future prompts
- [ ] Verify blocked devices can be unblocked from Settings

Closes #384