### PR TITLE
feat: Add Windows 11 support (MVP)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,9 +114,10 @@ jobs:
         shell: pwsh
         run: |
           $bundlePath = "${{ github.workspace }}\${{ matrix.target_path }}\src-tauri\target\debug\bundle"
-          $name = "${{ matrix.name }}"
-          Get-ChildItem -Path $bundlePath -Recurse -Directory | Where-Object { $_.Name -match 'msi|exe|appx' } | ForEach-Object {
-            Write-Host "Found artifact: $($_.FullName)"
+          if (Test-Path $bundlePath) {
+            & "${{ github.workspace }}\rename_build.ps1" -BaseDirectory $bundlePath -TauriVersion "${{ matrix.name }}" -DebugMode
+          } else {
+            Write-Host "Bundle path not found: $bundlePath"
           }
 
       - name: Upload result

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         include:
           - os: ubuntu-latest
           - os: macos-latest
+          - os: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -30,8 +31,8 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        if: contains(matrix.os, 'macos') == false
+      - name: Install dependencies (Linux)
+        if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev
@@ -60,6 +61,10 @@ jobs:
             name: main
             target_path: app/main
             cache_directory: app/main/src-tauri/target
+          - os: windows-latest
+            name: main
+            target_path: app/main
+            cache_directory: app/main/src-tauri/target
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -76,17 +81,17 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Linux dependencies for U
-        if: contains(matrix.os, 'macos') == false
+      - name: Install dependencies (Linux)
+        if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
-      - name: Install Linux dependencies
-        if: contains(matrix.os, 'macos') == false
+      - name: Install WebKitGTK dependencies (Linux)
+        if: contains(matrix.os, 'ubuntu')
         run: ${{ matrix.dependencies }}
 
       - name: GLIBC version
-        if: contains(matrix.os, 'macos') == false
+        if: contains(matrix.os, 'ubuntu')
         run: |
           GLIBC_VER=$(ldd --version | head -n1 | awk '{print $NF}')
           echo "GLIBC version: ${GLIBC_VER}"
@@ -97,8 +102,22 @@ jobs:
           cd ./${{ matrix.target_path }}
           pnpm install
           pnpm build:debug
+
+      - name: Rename build artifacts (Linux/macOS)
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+        run: |
           cd ${{ github.workspace }}
           ./rename_build.sh ${{ github.workspace }}/${{ matrix.target_path }}/src-tauri/target/debug/bundle/ ${{ matrix.name }}
+
+      - name: Rename build artifacts (Windows)
+        if: contains(matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          $bundlePath = "${{ github.workspace }}\${{ matrix.target_path }}\src-tauri\target\debug\bundle"
+          $name = "${{ matrix.name }}"
+          Get-ChildItem -Path $bundlePath -Recurse -Directory | Where-Object { $_.Name -match 'msi|exe|appx' } | ForEach-Object {
+            Write-Host "Found artifact: $($_.FullName)"
+          }
 
       - name: Upload result
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
           cd ./core_lib
           cargo test
           cargo build
+      - name: Test Windows artifact renaming
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./tests/rename_build.Tests.ps1
 
   build_tauri:
     runs-on: ${{ matrix.os }}
@@ -57,7 +61,7 @@ jobs:
             name: main
             target_path: app/main
             cache_directory: app/main/src-tauri/target
-          - os: macos-13
+          - os: macos-15-intel
             name: main
             target_path: app/main
             cache_directory: app/main/src-tauri/target
@@ -97,6 +101,7 @@ jobs:
           echo "GLIBC version: ${GLIBC_VER}"
 
       - name: Build Vite + Tauri
+        shell: bash
         run: |
           rm -rf ${{ github.workspace }}/${{ matrix.target_path }}/src-tauri/target/debug/bundle/
           cd ./${{ matrix.target_path }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,6 +62,12 @@ jobs:
           - directory: app/main/src-tauri
             clippy_args: "--no-default-features"
             os: ubuntu-24.04
+          - directory: core_lib
+            clippy_args: "--all-features --all"
+            os: windows-latest
+          - directory: app/main/src-tauri
+            clippy_args: "--no-default-features"
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -75,17 +81,18 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Linux dependencies for U
+      - name: Install Linux dependencies
+        if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
-      - name: Install Linux dependencies for U20.04
+      - name: Install WebKitGTK dependencies (Ubuntu 20.04)
         if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get install -y libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
 
-      - name: Install Linux dependencies for U24.04
+      - name: Install WebKitGTK dependencies (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt-get install -y libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
             name: main
             target_path: app/main
             cache_directory: app/main/src-tauri/target
+          - os: windows-latest
+            name: main
+            target_path: app/main
+            cache_directory: app/main/src-tauri/target
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -46,17 +50,17 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Linux dependencies for U
-        if: contains(matrix.os, 'macos') == false
+      - name: Install dependencies (Linux)
+        if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
-      - name: Install Linux dependencies
-        if: contains(matrix.os, 'macos') == false
+      - name: Install WebKitGTK dependencies (Linux)
+        if: contains(matrix.os, 'ubuntu')
         run: ${{ matrix.dependencies }}
 
       - name: GLIBC version
-        if: contains(matrix.os, 'macos') == false
+        if: contains(matrix.os, 'ubuntu')
         run: |
           GLIBC_VER=$(ldd --version | head -n1 | awk '{print $NF}')
           echo "GLIBC version: ${GLIBC_VER}"
@@ -67,8 +71,23 @@ jobs:
           cd ./${{ matrix.target_path }}
           pnpm install
           pnpm build
+
+      - name: Rename build artifacts (Linux/macOS)
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+        run: |
           cd ${{ github.workspace }}
           ./rename_build.sh ${{ github.workspace }}/${{ matrix.target_path }}/src-tauri/target/release/bundle/ ${{ matrix.name }}
+
+      - name: Rename build artifacts (Windows)
+        if: contains(matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          $bundlePath = "${{ github.workspace }}\${{ matrix.target_path }}\src-tauri\target\release\bundle"
+          if (Test-Path $bundlePath) {
+            & "${{ github.workspace }}\rename_build.ps1" -BaseDirectory $bundlePath -TauriVersion "${{ matrix.name }}"
+          } else {
+            Write-Host "Bundle path not found: $bundlePath"
+          }
 
       - name: Add files to release
         if: github.event_name != 'workflow_dispatch'
@@ -82,6 +101,6 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-debug-rquickshare-${{ matrix.os }}
+          name: artifact-release-rquickshare-${{ matrix.os }}
           path: |
             ${{ github.workspace }}/${{ matrix.target_path }}/src-tauri/target/release/bundle/*/r-quick-share-${{ matrix.name }}*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             name: main
             target_path: app/main
             cache_directory: app/main/src-tauri/target
-          - os: macos-13
+          - os: macos-15-intel
             name: main
             target_path: app/main
             cache_directory: app/main/src-tauri/target
@@ -66,6 +66,7 @@ jobs:
           echo "GLIBC version: ${GLIBC_VER}"
 
       - name: Build Vite + Tauri
+        shell: bash
         run: |
           rm -rf ${{ github.workspace }}/${{ matrix.target_path }}/src-tauri/target/release/bundle/
           cd ./${{ matrix.target_path }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>rquickshare</h1>
 
   <p>
-    <strong>NearbyShare/QuickShare for Linux and MacOS</strong>
+    <strong>NearbyShare/QuickShare for Linux, macOS, and Windows</strong>
   </p>
   <p>
 
@@ -31,6 +31,26 @@ You simply have to download the latest release.
 Simply install the .dmg.
 
 Note that you may have to first allow the app to install under `Settings > Privacy & Security > Security` (you should see a dialog asking for permission)
+
+#### Windows
+
+**Installer (.msi):**
+Run the `.msi` installer. This is the recommended installation method as it properly registers the application for notifications and autostart.
+
+**Portable (.zip):**
+Extract the ZIP archive to any folder and run the `.exe`. Note that:
+- Windows Firewall may block incoming connections. You may need to [add a firewall exception](#windows-firewall).
+- Notifications may not work properly — the app uses basic Windows toast notifications.
+- Autostart on login may require running as Administrator once to register.
+
+> [!WARNING]
+> **SmartScreen Warning:** Unsigned builds may show a "Windows protected your PC" warning from SmartScreen. Click "More info" → "Run anyway" to proceed. A code-signed release is planned.
+
+> [!NOTE]
+> **Windows Limitations (MVP):**
+> - **Wi-Fi LAN only** — same as Linux/macOS.
+> - **Bluetooth discovery** — Android devices may require manually opening the Quick Share receive UI on the phone. Automatic discovery via BLE advertising is planned for a future release.
+> - **Notifications** — Basic toast notifications only (no Accept/Reject action buttons). You'll need to open the app to accept transfers.
 
 #### Linux
 
@@ -164,6 +184,9 @@ vim ./.local/share/dev.mandre.rquickshare/.settings.json
 # mac
 vim Library/Application\ Support/dev.mandre.rquickshare/.settings.json
 
+# windows (PowerShell)
+notepad "$env:APPDATA\dev.mandre.rquickshare\.settings.json"
+
 # to be sure
 find $HOME -name ".settings.json"
 ```
@@ -193,10 +216,31 @@ env WEBKIT_DISABLE_COMPOSITING_MODE=1 rquickshare
 
 Alternatively, you may try the `legacy` variant.
 
+### Windows: Firewall is blocking incoming connections
+
+Windows Firewall blocks inbound TCP connections by default. If the app starts but other devices can't discover or connect to your Windows machine:
+
+1. **Quick fix (portable mode):** Open PowerShell as Administrator and run:
+   ```powershell
+   New-NetFirewallRule -DisplayName "RQuickShare" -Direction Inbound -Protocol TCP -Program "C:\path\to\r-quick-share.exe" -Action Allow
+   ```
+2. **Installer (.msi):** The MSI installer should prompt to add a firewall exception. If it doesn't, use the PowerShell command above.
+3. **Static port:** You can also set a static port in `.settings.json` (see above) and create a rule for that specific port:
+   ```powershell
+   New-NetFirewallRule -DisplayName "RQuickShare" -Direction Inbound -Protocol TCP -LocalPort 12345 -Action Allow
+   ```
+
+### Windows: App won't reopen after closing
+
+On Windows, closing the window minimizes the app to the system tray (same as Linux/macOS). The process continues running in the background.
+
+- **To fully exit:** Right-click the system tray icon → Quit.
+- **To close on window close:** Click the three dots in the app → "Stop app on close".
+
 WIP Notes
 --------------------------
 
-`rquickshare` is still in development (WIP) and currently only supports Linux even though it should be compatible with macOS too. Keep in mind that the design may change between versions, so flexibility is key.
+`rquickshare` is still in development (WIP) and supports Linux, macOS, and Windows. Keep in mind that the design may change between versions, so flexibility is key.
 
 Got feedback or suggestions? We'd love to hear them! Feel free to open an issue and share your thoughts.
 

--- a/core_lib/src/hdl/blea_win.rs
+++ b/core_lib/src/hdl/blea_win.rs
@@ -1,0 +1,30 @@
+use tokio_util::sync::CancellationToken;
+
+const INNER_NAME: &str = "BleAdvertiser";
+
+/// Windows stub implementation of the BLE advertiser.
+///
+/// This is a placeholder that returns an error indicating Windows BLE advertising
+/// is not yet implemented. The full implementation will use WinRT's
+/// `BluetoothLEAdvertisementPublisher` API to broadcast 0xFE2C service data.
+///
+/// See: deferred track `windows-impl_20260406` — Issue: "Implement BLE advertiser for automatic Android discovery"
+#[derive(Debug, Clone)]
+pub struct BleAdvertiser;
+
+impl BleAdvertiser {
+    pub async fn new() -> Result<Self, anyhow::Error> {
+        Err(anyhow::anyhow!(
+            "Windows BLE advertiser is not yet implemented. \
+             Android devices will require manual receive UI activation. \
+             See: https://github.com/Martichou/rquickshare/issues/TBD"
+        ))
+    }
+
+    pub async fn run(&self, ctk: CancellationToken) -> Result<(), anyhow::Error> {
+        warn!("{INNER_NAME}: Windows BLE advertiser not implemented, waiting for cancellation");
+        ctk.cancelled().await;
+        info!("{INNER_NAME}: tracker cancelled, returning");
+        Ok(())
+    }
+}

--- a/core_lib/src/hdl/blea_win.rs
+++ b/core_lib/src/hdl/blea_win.rs
@@ -16,8 +16,7 @@ impl BleAdvertiser {
     pub async fn new() -> Result<Self, anyhow::Error> {
         Err(anyhow::anyhow!(
             "Windows BLE advertiser is not yet implemented. \
-             Android devices will require manual receive UI activation. \
-             See: https://github.com/Martichou/rquickshare/issues/TBD"
+             Android devices will require manual receive UI activation."
         ))
     }
 

--- a/core_lib/src/hdl/inbound.rs
+++ b/core_lib/src/hdl/inbound.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::os::unix::fs::FileExt;
 use std::time::Duration;
 
 use anyhow::anyhow;
@@ -36,7 +35,7 @@ use crate::securemessage::{
 use crate::sharing_nearby::{paired_key_result_frame, text_metadata};
 use crate::utils::{
     encode_point, gen_ecdsa_keypair, gen_random, get_download_dir, hkdf_extract_expand,
-    stream_read_exact, to_four_digit_string, DeviceType, RemoteDeviceInfo,
+    stream_read_exact, to_four_digit_string, write_all_at_offset, DeviceType, RemoteDeviceInfo,
 };
 use crate::{location_nearby_connections, sharing_nearby};
 
@@ -652,11 +651,11 @@ impl InboundRequest {
                         }
 
                         if !chunk.body().is_empty() {
-                            file_internal
-                                .file
-                                .as_ref()
-                                .unwrap()
-                                .write_all_at(chunk.body(), current_offset as u64)?;
+                            write_all_at_offset(
+                                file_internal.file.as_ref().unwrap(),
+                                chunk.body(),
+                                current_offset as u64,
+                            )?;
                             file_internal.bytes_transferred += chunk_size as i64;
 
                             self.update_state(

--- a/core_lib/src/hdl/mod.rs
+++ b/core_lib/src/hdl/mod.rs
@@ -16,6 +16,10 @@ pub use ble::*;
 mod blea;
 #[cfg(all(feature = "experimental", target_os = "linux"))]
 pub use blea::*;
+#[cfg(all(feature = "experimental", target_os = "windows"))]
+mod blea_win;
+#[cfg(all(feature = "experimental", target_os = "windows"))]
+pub use blea_win::*;
 mod inbound;
 pub use inbound::*;
 pub(crate) mod info;

--- a/core_lib/src/hdl/outbound.rs
+++ b/core_lib/src/hdl/outbound.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
-use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::time::Duration;
 
@@ -681,7 +680,7 @@ impl OutboundRequest {
                     let fmeta = FileMetadata {
                         payload_id: Some(rand::rng().random::<i64>()),
                         name: Some(fname.to_os_string().into_string().unwrap()),
-                        size: Some(fmetadata.size() as i64),
+                        size: Some(fmetadata.len() as i64),
                         mime_type: Some(ftype),
                         r#type: Some(meta_type.into()),
                         ..Default::default()
@@ -697,7 +696,7 @@ impl OutboundRequest {
                         },
                     );
                     file_metadata.push(fmeta);
-                    total_to_send += fmetadata.size();
+                    total_to_send += fmetadata.len();
                 }
             }
         }

--- a/core_lib/src/lib.rs
+++ b/core_lib/src/lib.rs
@@ -189,6 +189,24 @@ impl RQS {
             });
         }
 
+        #[cfg(all(feature = "experimental", target_os = "windows"))]
+        {
+            let ctk_blea = ctk.clone();
+            tracker.spawn(async move {
+                let blea = match BleAdvertiser::new().await {
+                    Ok(b) => b,
+                    Err(e) => {
+                        warn!("Windows BLE advertiser not available: {}", e);
+                        return;
+                    }
+                };
+
+                if let Err(e) = blea.run(ctk_blea).await {
+                    warn!("Windows BLE advertiser stopped: {}", e);
+                }
+            });
+        }
+
         let discovery = MDnsDiscovery::new(sender)?;
         tracker.spawn(async move { discovery.run(ctk.clone()).await });
 

--- a/core_lib/src/lib.rs
+++ b/core_lib/src/lib.rs
@@ -6,7 +6,10 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use anyhow::anyhow;
 use channel::ChannelMessage;
-#[cfg(all(feature = "experimental", target_os = "linux"))]
+#[cfg(all(
+    feature = "experimental",
+    any(target_os = "linux", target_os = "windows")
+))]
 use hdl::BleAdvertiser;
 use hdl::MDnsDiscovery;
 use once_cell::sync::Lazy;
@@ -26,6 +29,7 @@ pub mod channel;
 mod errors;
 mod hdl;
 mod manager;
+mod offset_write;
 mod utils;
 
 pub use hdl::{EndpointInfo, OutboundPayload, State, Visibility};

--- a/core_lib/src/offset_write.rs
+++ b/core_lib/src/offset_write.rs
@@ -1,0 +1,139 @@
+use std::fs::File;
+use std::io;
+
+/// Write the entire buffer at an explicit byte offset.
+///
+/// Unix preserves the cursor. Windows `seek_write` changes it, as documented by
+/// std; callers must serialize cursor-based access to the same file. Inbound
+/// transfers already process each file's chunks sequentially at explicit offsets.
+pub fn write_all_at_offset(file: &File, data: &[u8], offset: u64) -> io::Result<()> {
+    offset
+        .checked_add(data.len() as u64)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "file write range overflows"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.write_all_at(data, offset)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileExt;
+        write_all_with(data, offset, |buffer, position| {
+            file.seek_write(buffer, position)
+        })
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (file, data, offset);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "offset writes require Unix or Windows",
+        ))
+    }
+}
+
+#[cfg(any(windows, test))]
+fn write_all_with(
+    mut data: &[u8],
+    mut offset: u64,
+    mut write: impl FnMut(&[u8], u64) -> io::Result<usize>,
+) -> io::Result<()> {
+    while !data.is_empty() {
+        match write(data, offset) {
+            Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
+            Ok(written) => {
+                offset = offset
+                    .checked_add(written as u64)
+                    .ok_or(io::ErrorKind::InvalidInput)?;
+                data = &data[written..];
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, OpenOptions};
+    use std::io::{Read, Seek, SeekFrom};
+
+    #[test]
+    fn offset_chunks_preserve_contents_and_documented_cursor() {
+        let path = std::env::temp_dir().join(format!(
+            "rquickshare-offset-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+        write_all_at_offset(&file, b"world", 5).unwrap();
+        write_all_at_offset(&file, b"hello", 0).unwrap();
+        file.seek(SeekFrom::Start(2)).unwrap();
+        write_all_at_offset(&file, b"!", 10).unwrap();
+        #[cfg(unix)]
+        assert_eq!(file.stream_position().unwrap(), 2);
+        #[cfg(windows)]
+        assert_eq!(file.stream_position().unwrap(), 11);
+        write_all_at_offset(&file, b"", 0).unwrap();
+        assert_eq!(
+            write_all_at_offset(&file, b"xx", u64::MAX)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut content = Vec::new();
+        file.read_to_end(&mut content).unwrap();
+        assert_eq!(content, b"helloworld!");
+        drop(file);
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn short_writes_and_interruptions_retry_at_exact_offsets() {
+        let mut calls = 0;
+        let mut positions = Vec::new();
+        write_all_with(b"abcde", 10, |data, position| {
+            calls += 1;
+            if calls == 1 {
+                return Err(io::ErrorKind::Interrupted.into());
+            }
+            positions.push((position, data.to_vec()));
+            Ok(data.len().min(2))
+        })
+        .unwrap();
+        assert_eq!(
+            positions,
+            vec![
+                (10, b"abcde".to_vec()),
+                (12, b"cde".to_vec()),
+                (14, b"e".to_vec())
+            ]
+        );
+    }
+
+    #[test]
+    fn zero_write_and_error_propagate_and_empty_input_does_not_write() {
+        assert_eq!(
+            write_all_with(b"x", 0, |_, _| Ok(0)).unwrap_err().kind(),
+            io::ErrorKind::WriteZero
+        );
+        assert_eq!(
+            write_all_with(b"x", 0, |_, _| Err(io::ErrorKind::PermissionDenied.into()))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        write_all_with(b"", 0, |_, _| panic!("empty buffer must not write")).unwrap();
+    }
+}

--- a/core_lib/src/utils.rs
+++ b/core_lib/src/utils.rs
@@ -218,6 +218,31 @@ pub fn is_not_self_ip(ip_address: &Ipv4Addr) -> bool {
     true
 }
 
+/// Cross-platform random-access file write.
+/// On Unix, uses `FileExt::write_all_at` (single syscall, no file position mutation).
+/// On Windows, uses `seek` + `write_all` (requires mutable access).
+pub fn write_all_at_offset(file: &std::fs::File, data: &[u8], offset: u64) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.write_all_at(data, offset)
+    }
+    #[cfg(windows)]
+    {
+        use std::io::{Seek, SeekFrom, Write};
+        let mut file = file.try_clone()?;
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(data)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        use std::io::{Seek, SeekFrom, Write};
+        let mut file = file.try_clone()?;
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(data)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core_lib/src/utils.rs
+++ b/core_lib/src/utils.rs
@@ -218,30 +218,7 @@ pub fn is_not_self_ip(ip_address: &Ipv4Addr) -> bool {
     true
 }
 
-/// Cross-platform random-access file write.
-/// On Unix, uses `FileExt::write_all_at` (single syscall, no file position mutation).
-/// On Windows, uses `seek` + `write_all` (requires mutable access).
-pub fn write_all_at_offset(file: &std::fs::File, data: &[u8], offset: u64) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::FileExt;
-        file.write_all_at(data, offset)
-    }
-    #[cfg(windows)]
-    {
-        use std::io::{Seek, SeekFrom, Write};
-        let mut file = file.try_clone()?;
-        file.seek(SeekFrom::Start(offset))?;
-        file.write_all(data)
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        use std::io::{Seek, SeekFrom, Write};
-        let mut file = file.try_clone()?;
-        file.seek(SeekFrom::Start(offset))?;
-        file.write_all(data)
-    }
-}
+pub use crate::offset_write::write_all_at_offset;
 
 #[cfg(test)]
 mod tests {

--- a/rename_build.ps1
+++ b/rename_build.ps1
@@ -1,0 +1,67 @@
+﻿# rename_build.ps1
+# Cross-platform build rename script for Windows CI
+# Usage: .\rename_build.ps1 -BaseDirectory "path\to\bundle" -TauriVersion "main" [-DebugMode]
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BaseDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$TauriVersion,
+
+    [switch]$DebugMode
+)
+
+# Find all relevant files in the base directory
+$extensions = @("*.msi", "*.exe", "*.appx")
+$files = @()
+foreach ($ext in $extensions) {
+    $files += Get-ChildItem -Path $BaseDirectory -Recurse -Filter $ext -File
+}
+
+if ($files.Count -eq 0) {
+    Write-Host "No Windows build artifacts found in $BaseDirectory"
+    exit 0
+}
+
+Write-Host "Found $($files.Count) Windows build artifact(s)"
+
+# Loop through each file
+foreach ($file in $files) {
+    $dir = $file.DirectoryName
+    $filename = $file.Name
+    $extension = $file.Extension.TrimStart('.')
+
+    # Extract version and variant from filename
+    # Patterns: r-quick-share_0.11.5_x64.msi, RQuickShare-0.11.5-1-x64.exe, etc.
+    $versionPattern = '([Rr](-[_]?)[Qq]uick([_-][Ss]hare))[_-]?([0-9]+\.[0-9]+\.[0-9]+)[_-]?(.*)\.' + [regex]::Escape($extension)
+
+    if ($filename -match $versionPattern) {
+        $version = "v$($Matches[4])"
+        $anything = $Matches[5].Trim('_-')
+    }
+    else {
+        # Fallback: use filename without extension as-is
+        $version = ""
+        $anything = $filename
+        Write-Host "Filename does not match expected pattern: $filename, using fallback"
+    }
+
+    # Construct new filename
+    $debugSuffix = if ($DebugMode) { "-debug" } else { "" }
+
+    if (-not [string]::IsNullOrEmpty($version)) {
+        $newFilename = "r-quick-share-${TauriVersion}${debugSuffix}_${version}_${anything}.${extension}"
+    }
+    else {
+        $newFilename = "r-quick-share-${TauriVersion}${debugSuffix}_${anything}.${extension}"
+    }
+
+    $newPath = Join-Path $dir $newFilename
+
+    # Rename the file
+    Rename-Item -Path $file.FullName -NewName $newFilename
+    Write-Host "Renamed $filename to $newPath"
+}
+
+Write-Host "Windows build renaming completed."

--- a/rename_build.ps1
+++ b/rename_build.ps1
@@ -12,6 +12,8 @@ param(
     [switch]$DebugMode
 )
 
+$ErrorActionPreference = 'Stop'
+
 # Find all relevant files in the base directory
 $extensions = @("*.msi", "*.exe", "*.appx")
 $files = @()
@@ -34,33 +36,30 @@ foreach ($file in $files) {
 
     # Extract version and variant from filename
     # Patterns: r-quick-share_0.11.5_x64.msi, RQuickShare-0.11.5-1-x64.exe, etc.
-    $versionPattern = '([Rr](-[_]?)[Qq]uick([_-][Ss]hare))[_-]?([0-9]+\.[0-9]+\.[0-9]+)[_-]?(.*)\.' + [regex]::Escape($extension)
+    $versionPattern = '^(?:r-quick-share|RQuickShare)[_-](?<version>[0-9]+\.[0-9]+\.[0-9]+)[_-](?<variant>.+)\.' + [regex]::Escape($extension) + '$'
 
     if ($filename -match $versionPattern) {
-        $version = "v$($Matches[4])"
-        $anything = $Matches[5].Trim('_-')
+        $version = "v$($Matches['version'])"
+        $anything = $Matches['variant']
     }
     else {
-        # Fallback: use filename without extension as-is
-        $version = ""
-        $anything = $filename
-        Write-Host "Filename does not match expected pattern: $filename, using fallback"
+        # Leave unrelated executables and previously renamed artifacts intact.
+        Write-Host "Skipping unrecognized artifact: $filename"
+        continue
     }
 
     # Construct new filename
     $debugSuffix = if ($DebugMode) { "-debug" } else { "" }
 
-    if (-not [string]::IsNullOrEmpty($version)) {
-        $newFilename = "r-quick-share-${TauriVersion}${debugSuffix}_${version}_${anything}.${extension}"
-    }
-    else {
-        $newFilename = "r-quick-share-${TauriVersion}${debugSuffix}_${anything}.${extension}"
-    }
+    $newFilename = "r-quick-share-${TauriVersion}${debugSuffix}_${version}_${anything}.${extension}"
 
     $newPath = Join-Path $dir $newFilename
 
     # Rename the file
-    Rename-Item -Path $file.FullName -NewName $newFilename
+    if (Test-Path -LiteralPath $newPath) {
+        throw "Refusing to overwrite existing artifact: $newPath"
+    }
+    Rename-Item -LiteralPath $file.FullName -NewName $newFilename
     Write-Host "Renamed $filename to $newPath"
 }
 

--- a/tests/rename_build.Tests.ps1
+++ b/tests/rename_build.Tests.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ('rquickshare-rename-' + [guid]::NewGuid())
+$scriptPath = Join-Path $PSScriptRoot '../rename_build.ps1'
+New-Item -ItemType Directory -Path $root | Out-Null
+try {
+    foreach ($name in @('r-quick-share_0.11.5_x64.msi', 'RQuickShare-0.11.5-1-x64.exe', 'helper.exe', 'r-quick-share_0.11.5_x64[en].appx')) {
+        [System.IO.File]::WriteAllText((Join-Path $root $name), $name)
+    }
+    & $scriptPath -BaseDirectory $root -TauriVersion main -DebugMode
+    $expected = @('r-quick-share-main-debug_v0.11.5_x64.msi', 'r-quick-share-main-debug_v0.11.5_1-x64.exe', 'helper.exe', 'r-quick-share-main-debug_v0.11.5_x64[en].appx') | Sort-Object
+    $actual = Get-ChildItem -LiteralPath $root -File | Select-Object -ExpandProperty Name | Sort-Object
+    if (Compare-Object $expected $actual) { throw 'Unexpected renamed filenames' }
+    & $scriptPath -BaseDirectory $root -TauriVersion main -DebugMode
+    $actual = Get-ChildItem -LiteralPath $root -File | Select-Object -ExpandProperty Name | Sort-Object
+    if (Compare-Object $expected $actual) { throw 'Renaming must be idempotent' }
+    [System.IO.File]::WriteAllText((Join-Path $root 'r-quick-share_0.11.5_x64.msi'), 'collision')
+    $rejected = $false
+    try { & $scriptPath -BaseDirectory $root -TauriVersion main -DebugMode } catch { $rejected = $true }
+    if (-not $rejected) { throw 'Existing destination was not protected' }
+    if ([System.IO.File]::ReadAllText((Join-Path $root 'r-quick-share-main-debug_v0.11.5_x64.msi')) -ne 'r-quick-share_0.11.5_x64.msi') { throw 'Existing destination was overwritten' }
+    Write-Host 'Artifact rename tests passed'
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force
+}


### PR DESCRIPTION
## Summary

Proposed initial Windows support for the existing open-source rquickshare client, alongside Linux and macOS. This remains a contribution awaiting upstream review, not a claim of production-ready Windows parity.

The motivation is a common, inspectable client across the three desktop platforms, useful for development, interoperability testing and users who prefer that implementation. It is not a claim that this is better supported or more reliable than Google's Windows Quick Share app.

## Windows scope and limitations

- Windows core/desktop build jobs and installer-artifact handling.
- Platform-neutral metadata sizing and explicit-offset inbound file writes.
- Windows BLE advertising remains an explicit unimplemented stub; no automatic Android discovery guarantee.
- Signing, runtime transfers, notifications, firewall behavior and production Windows support need separate evidence.

## Review follow-up

- Import the experimental BleAdvertiser under the Windows cfg as well as Linux.
- Recognize installer names with named captures; leave unknown executables intact, preserve existing destinations, and make repeated renaming a no-op.
- Replace the per-chunk cloned handle with a partial-write/Interrupted-aware Windows seek_write loop. Document correctly that Windows seek_write changes the cursor; Unix offset writes preserve it. Inbound processing is sequential at explicit offsets.
- Add deterministic offset/content/error tests and PowerShell artifact-renaming tests; run the latter in Windows CI.
- Remove the placeholder issues/TBD URL.
- Use Bash explicitly for the build/release shell steps containing rm commands.
- Replace obsolete macos-13 jobs with macos-15-intel while retaining the separate macos-latest lane.

## Validation

Local macOS: 16 library tests passed, standalone offset-write tests passed, PowerShell rename regressions passed, Rust formatting and actionlint passed. Clippy completed successfully with three existing warnings; no warning-free claim is made. Hosted Windows results will be recorded separately; local macOS execution is not Windows-build evidence.

No release or tag is being created by this update.
