### PR TITLE
feat: surface specific file system errors to UI (#194)

### DIFF
--- a/app/main/src/components/HomePage.vue
+++ b/app/main/src/components/HomePage.vue
@@ -136,6 +136,17 @@
 								</p>
 							</div>
 						</div>
+						<div v-if="item.error">
+							<p class="mt-2 text-red-600 font-bold">
+								Error
+							</p>
+							<p class="text-sm text-red-500 italic">
+								{{ item.error.data.message }}
+							</p>
+							<div v-if="isDebug">
+								<pre>{{ item.error.data.debug }}</pre>
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -196,6 +207,7 @@ export default {
 			enable,
 			disable,
 			dialogOpen,
+			isDebug: import.meta.env.DEV,
 			...utils
 		};
 	},

--- a/app/main/src/vue_lib/types.ts
+++ b/app/main/src/vue_lib/types.ts
@@ -12,6 +12,7 @@ export interface DisplayedItem {
 	name: string,
 	deviceType: DeviceType,
 	endpoint: boolean,
+	error?: string,
 
 	state?: State,
 	pin_code?: string,

--- a/app/main/src/vue_lib/utils.ts
+++ b/app/main/src/vue_lib/utils.ts
@@ -28,6 +28,7 @@ function _displayedItems(vm: TauriVM): Array<DisplayedItem> {
 			name: el.meta?.source?.name ?? 'Unknown',
 			deviceType: el.meta?.source?.device_type ?? 'Unknown',
 			endpoint: false,
+			error: el.error ?? undefined,
 
 			state: el.state ?? undefined,
 			pin_code: el.meta?.pin_code ?? undefined,

--- a/core_lib/src/channel.rs
+++ b/core_lib/src/channel.rs
@@ -27,6 +27,27 @@ pub enum TransferType {
     Outbound,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(tag = "type", content = "data")]
+pub enum ChannelError {
+    // Add other specific variants here as needed
+    Generic { message: String, debug: String },
+}
+
+pub trait ToChannelError {
+    fn to_channel_error(&self) -> ChannelError;
+}
+
+impl<E: std::fmt::Display + std::fmt::Debug> ToChannelError for E {
+    fn to_channel_error(&self) -> ChannelError {
+        ChannelError::Generic {
+            message: self.to_string(),
+            debug: format!("{:?}", self),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize, TS)]
 #[ts(export)]
 pub struct ChannelMessage {
@@ -40,4 +61,15 @@ pub struct ChannelMessage {
     pub rtype: Option<TransferType>,
     pub state: Option<State>,
     pub meta: Option<TransferMetadata>,
+    pub error: Option<ChannelError>,
+}
+
+impl ChannelMessage {
+    pub fn set_error<E: ToChannelError>(&mut self, err: E) {
+        self.error = Some(err.to_channel_error());
+    }
+    pub fn with_error<E: ToChannelError>(mut self, err: E) -> Self {
+        self.set_error(err);
+        self
+    }
 }

--- a/core_lib/src/hdl/inbound.rs
+++ b/core_lib/src/hdl/inbound.rs
@@ -1004,7 +1004,9 @@ impl InboundRequest {
         for id in ids {
             let mfi = self.state.transferred_files.get_mut(&id).unwrap();
 
-            let file = File::create(&mfi.file_url)?;
+            let file = File::create(&mfi.file_url).map_err(|e| {
+                anyhow::anyhow!("failed to create file at {}: {}", mfi.file_url.display(), e)
+            })?;
             info!("Created file: {:?}", &file);
             mfi.file = Some(file);
         }

--- a/core_lib/src/manager.rs
+++ b/core_lib/src/manager.rs
@@ -86,7 +86,7 @@ impl TcpServer {
                                                         direction: ChannelDirection::LibToFront,
                                                         state: Some(State::Disconnected),
                                                         ..Default::default()
-                                                    });
+                                                    }.with_error(&e));
                                                 }
                                                 error!("{INNER_NAME}: error while handling client: {e} ({:?})", ir.state.state);
                                                 break;


### PR DESCRIPTION
### Summary
Addresses Issue #194. Previously, when a destination path (like a disconnected USB drive) was unavailable, the software would report a generic "unexpected disconnection." 

This PR updates the communication layer to allow `ChannelMessage` to carry specific error data from the core library to the frontend. Users will now see a specific error message when a preselected path is nonexistent or inaccessible.

### Changes
- **Core (Rust):**
    - Added `ChannelError` enum and `ToChannelError` trait to standardize error serialization.
    - Updated `ChannelMessage` to include an optional `error` field.
    - Modified inbound request handling to catch and report specific filesystem failures when creating files.
- **UI (Vue):**
    - Updated `DisplayedItem` types and utility functions to support the new error field.
    - Added a red error message block to `HomePage.vue` to display the specific failure to the user.
    - Included a `debug` view for errors that triggers only in development mode.

### Testing
1. Set the download path to a disconnected drive or non-existent folder.
2. Attempt a file transfer.
3. Result: The UI now displays the specific error message (e.g., "failed to create file at...") instead of a vague disconnection notice.
<img width="596" height="554" alt="testing result" src="https://github.com/user-attachments/assets/df173e79-eaaf-4ffc-8a47-3dfcdbbae847" />
