### PR TITLE
Add conda environment.yml and build instructions for Ubuntu 26.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Installation
 You simply have to download the latest release.
 
 **Important notes:**
+
 - The minimum GLIBC version supported is included in the pkg name.
   - You can check yours with `ldd --version`.
 - RQuickShare was distributed with two version (main & legacy) up until v0.11.5:
@@ -44,21 +45,25 @@ RQuickShare requires one of the following libraries to be installed:
 The files should (in theory) install those dependencies by themselves, but if this is not the case you may have to install those manually.
 
 ##### Install rquickshare
+
 ```bash
 sudo dpkg -i r-quick-share_${VERSION}.deb
 ```
 
 #### Debian
+
 ```bash
 sudo dpkg -i r-quick-share_${VERSION}.deb
 ```
 
 #### RPM
+
 ```bash
 sudo rpm -i r-quick-share-${VERSION}.rpm
 ```
 
 #### DNF (preferred over RPM)
+
 ```bash
 sudo dnf install r-quick-share-${VERSION}.rpm
 ```
@@ -79,6 +84,93 @@ You can then either double click on it, or run it from the cmd line:
 
 ---
 
+Building from Source
+--------------------------
+
+Building rquickshare from source requires conda for the toolchain and GTK stack, plus 4 system packages for libraries not available on conda-forge.
+
+#### Prerequisites
+
+- [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (or full Anaconda)
+- `git`
+- An Ubuntu 26.04 LTS system (other distros may work with minor adjustments)
+
+#### Step 1: Install system dependencies
+
+The following packages are not available on conda-forge and must be installed via `apt`:
+
+```bash
+sudo apt update
+sudo apt install \
+  libwebkit2gtk-4.1-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev
+```
+
+> **Note:** `libwebkit2gtk-4.1-dev` provides the Tauri webview. `libayatana-appindicator3-dev` provides system tray support. `librsvg2-dev` is needed for the AppImage bundler.
+
+#### Step 2: Clone and setup the conda environment
+
+```bash
+git clone https://github.com/Martichou/rquickshare.git
+cd rquickshare
+conda env create -f environment.yml
+conda activate rquickshare
+```
+
+#### Step 3: Configure environment variables
+
+Add the following to your `~/.bashrc` (or `~/.zshrc`, etc.):
+
+> **Note:** These instructions assume conda is installed at `/home/user/miniconda3`. Adjust the `PKG_CONFIG_PATH` and `PKG_CONFIG_LIBDIR` values if your conda installation is located elsewhere (e.g., `~/.conda/envs/` or `/opt/conda/envs/`).
+
+```bash
+# PKG_CONFIG: find .pc files from both conda and system
+export PKG_CONFIG_PATH="/home/user/miniconda3/envs/rquickshare/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
+export PKG_CONFIG_LIBDIR="/home/user/miniconda3/envs/rquickshare/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
+
+# RUSTFLAGS: tell conda's cross-linker where to find system .so files
+export RUSTFLAGS="-L /usr/lib/x86_64-linux-gnu"
+```
+
+Then reload:
+
+```bash
+source ~/.bashrc
+```
+
+#### Step 4: Build
+
+**core_lib (Rust library):**
+
+```bash
+cd core_lib
+cargo build --release
+```
+
+**app/main (Tauri desktop app):**
+
+```bash
+cd app/main
+pnpm build
+```
+
+This produces three bundles:
+
+- `.deb` — for Debian/Ubuntu-based distributions
+- `.rpm` — for Fedora/RHEL-based distributions
+- `.AppImage` — portable, no installation required
+
+#### Quick build (one-liner)
+
+```bash
+conda activate rquickshare && \
+export PKG_CONFIG_PATH="/home/user/miniconda3/envs/rquickshare/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig" && \
+export PKG_CONFIG_LIBDIR="/home/user/miniconda3/envs/rquickshare/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig" && \
+export RUSTFLAGS="-L /usr/lib/x86_64-linux-gnu" && \
+cd app/main && pnpm build
+```
+
 <details>
 <summary>Unofficial Installation Methods</summary>
 
@@ -97,8 +189,9 @@ Available here: [NixOS](https://search.nixos.org/packages?channel=24.05&show=rqu
 A nix-shell will temporarily modify your $PATH environment variable. This can be used to try a piece of software before deciding to permanently install it.
 
 ```bash
-$ nix-shell -p rquickshare
+nix-shell -p rquickshare
 ```
+
 </details>
 
 ---
@@ -127,11 +220,11 @@ As a workaround, you can use the "[Files](https://play.google.com/store/apps/det
 A second workaround is to download a Shortcut maker (see [here](https://xdaforums.com/t/how-to-manually-create-a-homescreen-shortcut-to-a-known-unique-android-activity.4336833)) to create a shortcut to the particular intent:
 
 - Method A:
-	- Activity: `com.google.android.gms.nearby.sharing.ReceiveSurfaceActivity`
+  - Activity: `com.google.android.gms.nearby.sharing.ReceiveSurfaceActivity`
 
 - Method B:
-	- Action: `com.google.android.gms.RECEIVE_NEARBY`
-	- Mime type: `*/*`
+  - Action: `com.google.android.gms.RECEIVE_NEARBY`
+  - Mime type: `*/*`
 
 _Note: Samsung did something shady with Quick Share, so the above workaround may not work. Unfortunately, there's no alternative at the moment. Sorry._
 
@@ -174,14 +267,14 @@ find $HOME -name ".settings.json"
 
 ```json
 {
-	...existing_config...,
-	"port": 12345
+ ...existing_config...,
+ "port": 12345
 }
 ```
 
 By default the port is random (the OS will decide).
 
-### The app opens but I just get a blank window or cannot run it.
+### The app opens but I just get a blank window or cannot run it
 
 This happens for some users running Linux + NVIDIA cards.
 
@@ -205,9 +298,8 @@ Credits
 
 This project wouldn't exist without those amazing open-source project:
 
-- https://github.com/grishka/NearDrop
-- https://github.com/vicr123/QNearbyShare
-
+- <https://github.com/grishka/NearDrop>
+- <https://github.com/vicr123/QNearbyShare>
 
 Contributing
 --------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,126 @@
+name: rquickshare
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  # --- Toolchain ---
+  - rust=1.97
+  - pnpm=11
+  - protobuf=6.33
+  - pkg-config=0.29
+
+  # --- GTK stack (with .pc files for pkg-config) ---
+  - gtk3=3.24
+  - pango=1.56
+  - cairo=1.18
+  - atk-1.0=2.38
+  - gdk-pixbuf=2.44
+  - harfbuzz=12
+  - libsoup=3.6
+  - fontconfig=2.18
+  - freetype=2.14
+  - fribidi=1.0
+  - pixman=0.46
+  - epoxy=1.5
+
+  # --- GLib / GIO ---
+  - glib=2.86
+  - glib-tools=2.86
+  - libglib=2.86
+  - glib-networking=2.80
+
+  # --- GStreamer / media support ---
+  - libxml2=2.15
+  - libpng=1.6
+  - libwebp-base=1.6
+  - lerc=4.2
+  - libjpeg-turbo=3.2
+  - libtiff=4.7
+  - libdeflate=1.25
+
+  # --- X11 / Wayland ---
+  - libxcb=1.17
+  - xorg-libx11=1.8
+  - xorg-libxcomposite=0.4
+  - xorg-libxcursor=1.2
+  - xorg-libxdamage=1.1
+  - xorg-libxext=1.3
+  - xorg-libxfixes=6.0
+  - xorg-libxi=1.8
+  - xorg-libxinerama=1.1
+  - xorg-libxrandr=1.5
+  - xorg-libxrender=0.9
+  - xorg-libxtst=1.2
+  - xorg-libxxf86vm=1.1
+  - xorg-libice=1.1
+  - xorg-libsm=1.2
+  - xorg-libxau=1.0
+  - xkeyboard-config=2.48
+  - libxkbcommon=1.13
+  - wayland=1.26
+
+  # --- Networking ---
+  - openssl=3.6
+  - zlib=1.3
+  - libnghttp2=1.68
+  - c-ares=1.34
+  - libuv=1.52
+  - libpsl=0.21
+  - libbrotlienc=1.2
+  - libbrotlidec=1.2
+  - libbrotlicommon=1.2
+
+  # --- D-Bus / IPC ---
+  - dbus=1.16
+
+  # --- Crypto / security ---
+  - keyutils=1.6
+  - libffi=3.7
+  - libuuid=2.42
+  - liblzma=5.8
+
+  # --- Text / locale ---
+  - icu=78
+  - pcre2=10.46
+  - ncurses=6.6
+  - readline=8.3
+
+  # --- Compression ---
+  - bzip2=1.0
+  - zstd=1.5
+  - libzlib=1.3
+
+  # --- Graphics (OpenGL / EGL) ---
+  - libglvnd=1.7
+  - libgl=1.7
+  - libegl=1.7
+  - libglx=1.7
+  - libdrm=2.4
+
+  # --- System ---
+  - libstdcxx-ng=16
+  - libgcc-ng=16
+  - sysroot_linux-64=2.39
+  - binutils_impl_linux-64=2.46
+  - ld_impl_linux-64=2.46
+  - gcc_impl_linux-64=16.1
+
+  # --- Fonts ---
+  - font-ttf-dejavu-sans-mono=2.37
+  - font-ttf-inconsolata=3.0
+  - font-ttf-source-code-pro=2.3
+  - font-ttf-ubuntu=0.83
+
+  # --- Misc ---
+  - gettext=0.25
+  - gettext-tools=0.25
+  - hicolor-icon-theme=0.17
+  - protobuf-c=1.5
+  - graphite2=1.3
+  - libedit=3.1
+  - libpciaccess=0.19
+  - libcups=2.3
+  - libexpat=2.8
+  - libiconv=1.18
+  - libsqlite=3.53
+  - pthread-stubs=0.4


### PR DESCRIPTION
Hoping to do something nice, with this PR I propose an `environment.yml` file to reproduce the building environment I used through conda and an updated version of the `README.md` file with instructions on how to use it to build rquickshare from source on Ubuntu 26.04 LTS.

## Rationale

Building rquickshare currently requires a mix of system packages (apt) and manual environment configuration, which creates friction for new contributors and makes reproducing builds difficult. Moreover, when building from source on a personal account, one could not want to bloat their system with toolchains and development libraries. Therefore, this PR introduces:

1. **`environment.yml`** - a complete conda environment specification covering all packages available on conda-forge
2. **Updated build instructions** - step-by-step guide for building on Ubuntu 26.04 LTS using conda

This significantly reduces the "it works on my machine" problem while keeping the build reproducible and minimally invasive to the system (only 4 apt packages required that aren't available on conda-forge).

## What's included

### `environment.yml`

All conda-available dependencies are specified:

| Category | Packages |
| ---------- | ---------- |
| Toolchain | `rust`, `pnpm`, `protobuf`, `pkg-config` |
| GTK stack | `gtk3`, `pango`, `cairo`, `atk-1.0`, `gdk-pixbuf`, `harfbuzz`, `libsoup`, `fontconfig`, `freetype`, `pixman` |
| GLib/GIO | `glib`, `glib-tools`, `libglib`, `glib-networking` |
| Media | `libxml2`, `libpng`, `libwebp-base`, `libtiff`, `libjpeg-turbo`, `lerc` |
| X11/Wayland | `libxcb`, `libxkbcommon`, `wayland`, `xorg-lib*` |
| Networking | `openssl`, `libnghttp2`, `c-ares`, `libuv`, `libpsl`, `libbrotli*` |
| D-Bus | `dbus` |
| Crypto | `keyutils`, `libffi`, `libuuid`, `liblzma` |
| System | `libstdcxx-ng`, `libgcc-ng`, `sysroot_linux-64`, `gcc_impl_linux-64`, `binutils_impl_linux-64` |
| Fonts | `font-ttf-dejavu-sans-mono`, `font-ttf-inconsolata`, `font-ttf-source-code-pro`, `font-ttf-ubuntu` |

### Build instructions

Updated README.md with:

1. **Prerequisites** - conda installation, git clone
2. **Environment setup** - `conda env create -f environment.yml`, `conda activate rquickshare`
3. **Required apt packages** - the 4 packages not available on conda-forge
4. **Environment variables** - `PKG_CONFIG_PATH`, `PKG_CONFIG_LIBDIR`, `RUSTFLAGS`
5. **Build commands** - `core_lib` and `app/main` builds

## Why the 4 apt packages?

Conda-forge doesn't distribute development headers with `-dev`/`-devel` suffixes the way apt does. The GTK stack on conda-forge bundles everything together, but:

- **WebKitGTK** (`libwebkit2gtk-4.1-dev`) - Tauri's embedded webview. Not on conda-forge at all.
- **JavaScriptCoreGTK** - Part of WebKitGTK, bundled with the above.
- **Ayatana AppIndicator** (`libayatana-appindicator3-dev`) - System tray icon support. Not on conda-forge.
- **librsvg** (`librsvg2-dev`) - Runtime exists on conda-forge but no `.pc` files shipped, so pkg-config can't find it for the AppImage bundler.

## Environment variables

These three exports are required for the conda cross-linker to find system libraries:

```bash
export PKG_CONFIG_PATH="/home/user/miniconda3/envs/rquickshare/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
export PKG_CONFIG_LIBDIR="/home/user/miniconda3/envs/rquickshare/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
export RUSTFLAGS="-L /usr/lib/x86_64-linux-gnu"
```

## Files changed

- `environment.yml` - new, full conda environment spec
- `README.md` - updated build instructions with conda steps

## Testing

Verified on Ubuntu 26.04 LTS:

- ✅ `conda env create -f environment.yml` - environment created successfully
- ✅ `cargo build` in `core_lib` - compiles without errors
- ✅ `pnpm build` in `app/main` - produces `.deb`, `.rpm` and `.AppImage` bundles

## Notes for maintainers

The `RUSTFLAGS="-L /usr/lib/x86_64-linux-gnu"` is needed because conda's cross-compiler uses an empty sysroot. The `.pc` files from conda-forge packages are in the conda env's `lib/pkgconfig/`, but the actual `.so` files from system libraries (WebKitGTK, AppIndicator) live outside the sysroot.

Future improvement: If conda-forge gains WebKitGTK support, this could become fully conda-contained.